### PR TITLE
fix: station13のテストでcheckboxがviewportにないためにエラーが出ていた問題を修正

### DIFF
--- a/src/station13.html
+++ b/src/station13.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Station 13</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/JNKKKK/MoreToggles.css@0.2.1/output/moretoggles.min.css">
   </head>
   <body>
     <main>


### PR DESCRIPTION
https://github.com/TechTrain-Community/RailwayForum/discussions/140

Playwrightでcheckboxをselectorで探そうとしたら、viewport errorが出ていた。
iOS Style のCSSが特殊で、checkboxのinput要素を隠していた。

