### PR TITLE
fix: selectorが複数のsectionタグをマッチしてstrict mode errorになっていた問題を修正

### DIFF
--- a/playwright/station06.spec.ts
+++ b/playwright/station06.spec.ts
@@ -6,12 +6,12 @@ test.beforeEach(async ({ page }) => {
 
 test('<article>, <section>が正しく使われている', async ({ page }) => {
   await expect(page.locator('body > article')).toBeVisible()
-  await expect(page.locator('article > section')).toBeVisible()
+  await expect(page.locator('article > section').first()).toBeVisible()
 })
 
 test('<section>にwidth: 600px, margin-bottom: 50pxが適用されている', async ({
   page,
 }) => {
-  await expect(page.locator('section')).toHaveCSS('width', '600px')
-  await expect(page.locator('section')).toHaveCSS('margin-bottom', '50px')
+  await expect(page.locator('section').first()).toHaveCSS('width', '600px')
+  await expect(page.locator('section').first()).toHaveCSS('margin-bottom', '50px')
 })


### PR DESCRIPTION
https://github.com/TechTrain-Community/RailwayForum/discussions/143

sectionが複数ある場合にテストがエラーになっていた。
Playwrightのstrict modeでlocator('section')が複数のDOMにマッチしてしまっていた。
Cypressの場合はそういう場合でも誤魔化してくれるが、PlaywrightのDOM選択は厳密なのでエラーとなる。

この問題ではsectionを何個使うのかが明示されていない、かつ問題文からも読み取れないため、firstだけチェックするテストにした。